### PR TITLE
gate classes.rs behind `generated` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/UniversalGameExtraction/RustyAssetBundleEXtractor"
 
+[features]
+generated = []
 
 [dependencies]
 # Binary Reader/Write - https://crates.io/crates/binary-reader

--- a/src/objects/classes.rs
+++ b/src/objects/classes.rs
@@ -1,4 +1,5 @@
 #![allow(warnings)]
+#![cfg(feature = "generated")]
 use crate::objects::PPtr;
 use serde::{Deserialize, Serialize};
 

--- a/utils/class_generator/generator.py
+++ b/utils/class_generator/generator.py
@@ -102,6 +102,7 @@ class AllClassHandler:
         f.writelines(
             [
                 "#![allow(warnings)]\n",
+                "#![cfg(feature = \"generated\")]\n",
                 "use crate::objects::PPtr;\n",
                 "use serde::{Deserialize, Serialize};\n",
                 "\n",


### PR DESCRIPTION
When classes.rs is enabled, every change I do leads to 10 extra seconds each `cargo check`, and rust-analyzer becomes way less responsive.
I think it'd be good to opt in to this if you do want it.

It could also be split into different features for the common stuff like `Transform` etc so that you don't always have to 504307 lines of generated serde code.