### PR TITLE
Fix lzma decompress option

### DIFF
--- a/src/files/bundlefile.rs
+++ b/src/files/bundlefile.rs
@@ -325,7 +325,9 @@ impl BundleFile {
             CompressionType::Lzma => {
                 let mut compressed_reader = std::io::Cursor::new(&compressed);
                 let mut uncompressed = vec![0; block.uncompressed_size as usize];
-                lzma_rs::lzma_decompress(&mut compressed_reader, &mut uncompressed).unwrap();
+                let mut option = lzma_rs::decompress::Options::default();
+                option.unpacked_size = lzma_rs::decompress::UnpackedSize::UseProvided(Some(block.compressed_size as u64));
+                lzma_rs::lzma_decompress_with_options(&mut compressed_reader, &mut uncompressed, &option).unwrap();
                 Ok(uncompressed)
             }
             CompressionType::Lz4 | CompressionType::Lz4hc => {


### PR DESCRIPTION
Unity will not include `compressed_size` in data while `lzma_decompress` use default Options which read `unpacked_size` from data. So use `lzma_decompress_with_options`  with `UnpackedSize::UseProvided` instead.